### PR TITLE
Export CborStreamBreak.

### DIFF
--- a/codec/cbor.go
+++ b/codec/cbor.go
@@ -40,7 +40,7 @@ const (
 	CborStreamString      = 0x7f
 	CborStreamArray       = 0x9f
 	CborStreamMap         = 0xbf
-	cborStreamBreak       = 0xff
+	CborStreamBreak       = 0xff
 )
 
 const (


### PR DESCRIPTION
`CborStreamBreak` should be exported so that it is available for use in emitting indefinite-length streams, as described in the documentation.